### PR TITLE
fixed preg_replace for php compiled PCRE versions

### DIFF
--- a/ConnectorOrsr.php
+++ b/ConnectorOrsr.php
@@ -525,7 +525,7 @@ class ConnectorOrsr
 			'&nbsp;' => ' ',
 		]);
 
-		$html = preg_replace('/\s+/', ' ', $html);
+		$html = preg_replace('/\s+/u', ' ', $html);
 
 		// load XHTML into DOM document
 		$xml = new \DOMDocument('1.0', 'utf-8');
@@ -554,7 +554,7 @@ class ConnectorOrsr
 						if($firstCol->length){
 							$firstCol = $firstCol->item(0)->nodeValue;
 							if($firstCol){
-								$firstCol = preg_replace('/\s+/', ' ', $firstCol);
+								$firstCol = preg_replace('/\s+/u', ' ', $firstCol);
 								foreach($tags as $tag => $callback){
 									if(false !== mb_stripos($firstCol, $tag, 0, 'utf-8')){
 										$secondCol = $xpath->query(".//td[2]", $node);
@@ -703,7 +703,7 @@ class ConnectorOrsr
 
 	protected function extract_ico($tag, $node, $xpath){
 		$out = self::getFirstTableFirstCell($node, $xpath);
-		$out = preg_replace('/\s+/', '', $out);
+		$out = preg_replace('/\s+/u', '', $out);
 		return ['ico' => $out];
 	}
 
@@ -1088,7 +1088,7 @@ class ConnectorOrsr
 		];
 		if(preg_match('/([^\d]+)( [\d ]+)/', $city, $match)){
 			$out['city'] = trim($match[1]);
-			$out['zip'] = preg_replace('/\s/','', $match[2]); // remove inline whitespaces
+			$out['zip'] = preg_replace('/\s/u','', $match[2]); // remove inline whitespaces
 		}
 		return $out;
 	}


### PR DESCRIPTION
Ahoj,

vdaka za tvoj super balicek, no po istom case sa vyskytla chyba, ktora sa stava len v niektorych PHP prostrediach. Na zaklade toho, ako bolo PHP na danom OS skompilovane.

Ide o chybu, kedy **preg_replace('/\s+/', ' ', $html)** vracia nespravne kodovanie jazyka, preto je potrebne pouzit flag **u**. Kedze preg_replace pokazilo kodovanie, $xml->loadHTML nefungoval, a kod hodil chybu, tak isto pri vybere textu zo stlpcov pomocou xx->nodeValue, sa odstranili prazdne medzery, v tomto pripade sa taktiez pokazilo kodovanie, atd... Takze kod nefungoval spravne.

Zmeny som otestoval, su funkcne. Prosim o merge a vytvorenie noveho Tagu. 

V tomto vlakne je vysvetlene, co sa vlastne deje:
https://stackoverflow.com/questions/35887031/why-does-w-match-non-english-characters-in-mac-os-x-php-environment

Dakujem velmi pekne, pekny den.

Preg_replace does not work same on every PHP environment. This depends on which way is PHP compiled. More about bug here:
https://stackoverflow.com/questions/35887031/why-does-w-match-non-english-characters-in-mac-os-x-php-environment