### PR TITLE
file_get_contents(): Passing null to parameter #2 () of type bool is …

### DIFF
--- a/ConnectorOrsr.php
+++ b/ConnectorOrsr.php
@@ -155,7 +155,7 @@ class ConnectorOrsr
 			]
 		]);
 
-		return file_get_contents($url, null, $ctx);
+		return file_get_contents($url, false, $ctx);
 	}
 
 	/**


### PR DESCRIPTION
…deprecated